### PR TITLE
feat: add product API routes with random destination

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -31,6 +31,9 @@ const nextConfig = {
   },
   reactStrictMode: true,
   redirects,
+  experimental: {
+    runtime: 'nodejs',
+  },
 }
 
 export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,43 @@
+import type { NextRequest } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+
+export const runtime = 'nodejs'
+
+const select = {
+  slug: true,
+  listingName: true,
+  summary: true,
+  heroImage: true,
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const payload = await getPayload({ config })
+  const { searchParams } = new URL(req.url)
+
+  const limit = parseInt(searchParams.get('limit') ?? '50', 10)
+  const page = parseInt(searchParams.get('page') ?? '1', 10)
+
+  const products = await payload.find({
+    collection: 'products',
+    where: { status: { equals: 'published' } },
+    limit,
+    page,
+    select,
+  })
+
+  return Response.json(
+    {
+      docs: products.docs,
+      totalDocs: products.totalDocs,
+      totalPages: products.totalPages,
+      page: products.page,
+      limit: products.limit,
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    },
+  )
+}

--- a/src/app/api/random-product/route.ts
+++ b/src/app/api/random-product/route.ts
@@ -1,0 +1,61 @@
+import { getPayload } from 'payload'
+import config from '@payload-config'
+
+export const runtime = 'nodejs'
+
+const select = {
+  slug: true,
+  listingName: true,
+  summary: true,
+  heroImage: true,
+  destinations: true,
+}
+
+function pickWeightedDestination(destinations: any[]): any | undefined {
+  const total = destinations.reduce((sum, d) => sum + (d?.weight || 0), 0)
+  if (total === 0) return undefined
+  const r = Math.random() * total
+  let acc = 0
+  for (const dest of destinations) {
+    acc += dest?.weight || 0
+    if (r < acc) return dest
+  }
+  return destinations[0]
+}
+
+export async function GET(): Promise<Response> {
+  const payload = await getPayload({ config })
+
+  const products = await payload.find({
+    collection: 'products',
+    where: { status: { equals: 'published' } },
+    pagination: false,
+    select,
+  })
+
+  if (!products.docs.length) {
+    return Response.json(null, {
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    })
+  }
+
+  const product = products.docs[Math.floor(Math.random() * products.docs.length)] as any
+
+  const destination = pickWeightedDestination(product.destinations || [])
+
+  const result = {
+    slug: product.slug,
+    listingName: product.listingName,
+    summary: product.summary,
+    heroImage: product.heroImage,
+    destination,
+  }
+
+  return Response.json(result, {
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add products listing API endpoint using Payload
- add random product endpoint with weighted destination selection
- ensure Node runtime by config update

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing secret key)*

------
https://chatgpt.com/codex/tasks/task_e_689f7b97a394832a8e9c127afbb7cba0