### PR TITLE
feat: add redirect route with weighted destinations

### DIFF
--- a/src/app/go/[slug]/route.ts
+++ b/src/app/go/[slug]/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+
+import { getServerSideURL } from '@/utilities/getURL'
+
+export const runtime = 'nodejs'
+
+const BOT_REGEX = /bot|crawl|spider|slurp|fetch|crawler/i
+
+export async function GET(
+  req: Request,
+  { params }: { params: { slug: string } },
+): Promise<Response> {
+  const { slug } = params
+  const payload = await getPayload({ config: configPromise })
+
+  const { docs } = await payload.find<{ destinations?: any[] }>({
+    collection: 'products',
+    where: { slug: { equals: slug } },
+    limit: 1,
+    depth: 0,
+  })
+
+  const product = docs?.[0]
+
+  if (!product) {
+    return new Response('Not found', { status: 404, headers: { 'Cache-Control': 'no-store' } })
+  }
+
+  const destinations = (product.destinations || []).filter((d: any) => d.active)
+
+  if (!destinations.length) {
+    return new Response('No destinations', { status: 404, headers: { 'Cache-Control': 'no-store' } })
+  }
+
+  const siteSettings = await payload.findGlobal<{ defaultUTMParams?: { key: string; value: string }[] }>({
+    slug: 'site-settings',
+  })
+
+  const utmParams: Record<string, string> = {}
+  siteSettings?.defaultUTMParams?.forEach(({ key, value }) => {
+    utmParams[key] = value
+  })
+
+  const totalWeight = destinations.reduce(
+    (sum: number, d: any) => sum + (typeof d.weight === 'number' ? d.weight : 0),
+    0,
+  )
+
+  let threshold = Math.random() * totalWeight
+  let chosen = destinations[0]
+  for (const d of destinations) {
+    threshold -= typeof d.weight === 'number' ? d.weight : 0
+    if (threshold <= 0) {
+      chosen = d
+      break
+    }
+  }
+
+  const destURL = new URL(chosen.url)
+  Object.entries(utmParams).forEach(([key, value]) => {
+    destURL.searchParams.append(key, value)
+  })
+
+  const ua = req.headers.get('user-agent') || ''
+  if (BOT_REGEX.test(ua)) {
+    const productURL = new URL(`/products/${slug}`, getServerSideURL())
+    const html = `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=${productURL.toString()}"></head><body></body></html>`
+    return new Response(html, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    })
+  }
+
+  return NextResponse.redirect(destURL.toString(), {
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  })
+}

--- a/src/globals/SiteSettings.ts
+++ b/src/globals/SiteSettings.ts
@@ -1,0 +1,32 @@
+import type { GlobalConfig } from 'payload'
+
+export const SiteSettings: GlobalConfig = {
+  slug: 'site-settings',
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'defaultUTMParams',
+      label: 'Default UTM Params',
+      type: 'array',
+      fields: [
+        {
+          name: 'key',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'value',
+          type: 'text',
+          required: true,
+        },
+      ],
+      admin: {
+        description: 'Key-value pairs appended to outbound links as query parameters.',
+      },
+    },
+  ],
+}
+
+export default SiteSettings

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -13,6 +13,7 @@ import { Posts } from './collections/Posts'
 import { Users } from './collections/Users'
 import { Footer } from './Footer/config'
 import { Header } from './Header/config'
+import { SiteSettings } from './globals/SiteSettings'
 import { plugins } from './plugins'
 import { defaultLexical } from '@/fields/defaultLexical'
 import { getServerSideURL } from './utilities/getURL'
@@ -66,7 +67,7 @@ export default buildConfig({
   }),
   collections: [Pages, Posts, Media, Categories, Users],
   cors: [getServerSideURL()].filter(Boolean),
-  globals: [Header, Footer],
+  globals: [Header, Footer, SiteSettings],
   plugins: [
     ...plugins,
     vercelBlobStorage({


### PR DESCRIPTION
## Summary
- add SiteSettings global for default UTM params
- add go/[slug] redirect route with weighted destination selection and bot handling
- register SiteSettings global in Payload config

## Testing
- `pnpm lint`
- `pnpm test:int` *(fails: missing secret key)*
- `pnpm test:e2e` *(fails: --no-experimental-strip-types not allowed in NODE_OPTIONS)*

------
https://chatgpt.com/codex/tasks/task_e_689f7b9b0dfc832a9156e31bdb60b010