### PR TITLE
feat: add homepage hero and featured products

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "dotenv": "16.4.7",
     "geist": "^1.3.0",
     "graphql": "^16.8.2",
+    "framer-motion": "^11.0.20",
     "lucide-react": "^0.378.0",
     "next": "15.4.4",
     "next-sitemap": "^4.2.3",

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,5 +1,66 @@
-import PageTemplate, { generateMetadata } from './[slug]/page'
+import React from 'react'
 
-export default PageTemplate
+import { HomepageHero } from '@/components/(marketing)/HomepageHero'
+import { Media } from '@/components/Media'
+import { Button } from '@/components/ui/button'
+import configPromise from '@payload-config'
+import Link from 'next/link'
+import { getPayload } from 'payload'
 
-export { generateMetadata }
+export default async function Page() {
+  const payload = await getPayload({ config: configPromise })
+
+  const result = await payload.find({
+    collection: 'products',
+    limit: 3,
+    sort: 'featuredOrder',
+    where: {
+      featured: {
+        equals: true,
+      },
+    },
+  })
+
+  const products = result.docs as any[]
+
+  return (
+    <div className="pt-24 pb-24">
+      <HomepageHero products={products} />
+
+      <section className="container mt-16 grid gap-12 sm:grid-cols-2 lg:grid-cols-3">
+        {products.map((product) => {
+          const image = product.image || product?.meta?.image
+
+          return (
+            <article key={product.slug} className="text-center">
+              {image && typeof image !== 'string' && (
+                <Media
+                  className="mx-auto w-full max-w-xs"
+                  resource={image}
+                  size="400px"
+                />
+              )}
+
+              {product.title && (
+                <h3 className="mt-4 text-xl font-semibold">{product.title}</h3>
+              )}
+
+              {product.slug && (
+                <div className="mt-4 flex justify-center">
+                  <Button asChild>
+                    <Link prefetch={false} href={`/p/${product.slug}`}>
+                      View Product
+                    </Link>
+                  </Button>
+                </div>
+              )}
+            </article>
+          )
+        })}
+      </section>
+    </div>
+  )
+}
+
+export { generateMetadata } from './[slug]/page'
+

--- a/src/components/(marketing)/HomepageHero/index.tsx
+++ b/src/components/(marketing)/HomepageHero/index.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { Media } from '@/components/Media'
+import { AnimatePresence, motion } from 'framer-motion'
+import React, { useEffect, useState } from 'react'
+
+type Product = {
+  slug?: string
+  title?: string
+  image?: any
+  meta?: {
+    image?: any
+  }
+}
+
+export const HomepageHero: React.FC<{ products: Product[] }> = ({ products }) => {
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    if (!products || products.length < 2) return
+
+    const timer = setInterval(() => {
+      setIndex((i) => (i + 1) % products.length)
+    }, 5000)
+
+    return () => clearInterval(timer)
+  }, [products])
+
+  const current = products[index]
+  const image = current?.image || current?.meta?.image
+
+  return (
+    <div className="relative h-96 w-full overflow-hidden">
+      <AnimatePresence initial={false}>
+        {image && typeof image !== 'string' && (
+          <motion.div
+            key={current?.slug || index}
+            className="absolute inset-0"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.8 }}
+          >
+            <Media fill imgClassName="object-cover" resource={image} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+      {current?.title && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+          <h1 className="text-4xl font-bold text-white">{current.title}</h1>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default HomepageHero
+


### PR DESCRIPTION
## Summary
- fetch and display featured products sorted by order on the homepage
- add marketing hero with motion image carousel
- include framer-motion dependency for carousel

## Testing
- `pnpm test` *(fails: missing secret key)*

------
https://chatgpt.com/codex/tasks/task_e_689f7b9ce3d0832aa12fed9f6fb8d6f0