### PR TITLE
Ensure image alt text and optimized loading

### DIFF
--- a/next-sitemap.config.cjs
+++ b/next-sitemap.config.cjs
@@ -7,7 +7,15 @@ const SITE_URL =
 module.exports = {
   siteUrl: SITE_URL,
   generateRobotsTxt: true,
-  exclude: ['/posts-sitemap.xml', '/pages-sitemap.xml', '/*', '/posts/*'],
+  exclude: [
+    '/posts-sitemap.xml',
+    '/pages-sitemap.xml',
+    '/p-sitemap.xml',
+    '/api/*',
+    '/posts/*',
+    '/p/*',
+    '/*',
+  ],
   robotsTxtOptions: {
     policies: [
       {
@@ -15,6 +23,10 @@ module.exports = {
         disallow: '/admin/*',
       },
     ],
-    additionalSitemaps: [`${SITE_URL}/pages-sitemap.xml`, `${SITE_URL}/posts-sitemap.xml`],
+    additionalSitemaps: [
+      `${SITE_URL}/pages-sitemap.xml`,
+      `${SITE_URL}/posts-sitemap.xml`,
+      `${SITE_URL}/p-sitemap.xml`,
+    ],
   },
 }

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -46,8 +46,4 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 export const metadata: Metadata = {
   metadataBase: new URL(getServerSideURL()),
   openGraph: mergeOpenGraph(),
-  twitter: {
-    card: 'summary_large_image',
-    creator: '@payloadcms',
-  },
 }

--- a/src/blocks/MediaBlock/Component.tsx
+++ b/src/blocks/MediaBlock/Component.tsx
@@ -45,6 +45,7 @@ export const MediaBlock: React.FC<Props> = (props) => {
       {(media || staticImage) && (
         <Media
           imgClassName={cn('border border-border rounded-[0.8rem]', imgClassName)}
+          loading="lazy"
           resource={media}
           src={staticImage}
         />

--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -26,7 +26,7 @@ export const Media: CollectionConfig = {
     {
       name: 'alt',
       type: 'text',
-      //required: true,
+      required: true,
     },
     {
       name: 'caption',

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -83,6 +83,13 @@ export const Posts: CollectionConfig<'posts'> = {
               name: 'heroImage',
               type: 'upload',
               relationTo: 'media',
+              fields: [
+                {
+                  name: 'alt',
+                  type: 'text',
+                  required: true,
+                },
+              ],
             },
             {
               name: 'content',

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -39,7 +39,9 @@ export const Card: React.FC<{
     >
       <div className="relative w-full ">
         {!metaImage && <div className="">No image</div>}
-        {metaImage && typeof metaImage !== 'string' && <Media resource={metaImage} size="33vw" />}
+        {metaImage && typeof metaImage !== 'string' && (
+          <Media loading="lazy" resource={metaImage} size="33vw" />
+        )}
       </div>
       <div className="p-4">
         {showCategories && hasCategories && (

--- a/src/heros/config.ts
+++ b/src/heros/config.ts
@@ -66,6 +66,13 @@ export const hero: Field = {
       },
       relationTo: 'media',
       required: true,
+      fields: [
+        {
+          name: 'alt',
+          type: 'text',
+          required: true,
+        },
+      ],
     },
   ],
   label: false,


### PR DESCRIPTION
## Summary
- require alt text for media, hero images, and page hero media
- lazy-load non-hero images and keep hero images prioritized
- trim unused metadata and expand sitemap coverage for product routes

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing secret key)*
- `npx -y lighthouse http://localhost:3000 --quiet --chrome-flags="--headless"` *(fails: The CHROME_PATH environment variable must be set to a Chrome/Chromium executable no older than Chrome stable)*

------
https://chatgpt.com/codex/tasks/task_e_689f7ba39c38832aa2c3c892db180d07