### PR TITLE
refactor: rename post components for products

### DIFF
--- a/src/app/(frontend)/p/[slug]/page.tsx
+++ b/src/app/(frontend)/p/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { draftMode } from 'next/headers'
 import { getPayload } from 'payload'
 import configPromise from '@payload-config'
 import React, { cache } from 'react'
+import { ProductHero } from '@/heros/ProductHero'
+import { RelatedProducts } from '@/blocks/RelatedProducts/Component'
 
 // Types for product data returned from Payload
 interface Product {
@@ -48,7 +50,7 @@ export default async function ProductPage({ params: paramsPromise }: Args) {
 
   return (
     <article className="pt-16 pb-24">
-      <Hero product={product} />
+      <ProductHero product={product} />
       <Carousel images={product.images} />
       <ShortDescription text={product.shortDescription} />
       <FeatureTrio features={product.features} />
@@ -98,14 +100,6 @@ const queryRelatedProducts = cache(async ({ tags, slug }: { tags: string[]; slug
   })
   return result.docs as Product[]
 })
-
-function Hero({ product }: { product: Product }) {
-  return (
-    <section className="container">
-      <h1 className="text-4xl font-bold text-center">{product.title}</h1>
-    </section>
-  )
-}
 
 function Carousel({ images = [] }: { images?: { url: string; alt?: string }[] }) {
   if (!images.length) return null
@@ -162,21 +156,6 @@ function PrimaryCTA({ slug }: { slug: string }) {
   )
 }
 
-function RelatedProducts({ products = [] }: { products: Product[] }) {
-  if (!products.length) return null
-  return (
-    <section className="container mt-16">
-      <h2 className="text-2xl font-bold mb-6">Related products</h2>
-      <div className="grid gap-6 md:grid-cols-3">
-        {products.map((p) => (
-          <Link key={p.slug} href={`/p/${p.slug}`} className="block border rounded p-4">
-            {p.title}
-          </Link>
-        ))}
-      </div>
-    </section>
-  )
-}
 
 function StickyCTA({ slug }: { slug: string }) {
   return (

--- a/src/blocks/RelatedProducts/Component.tsx
+++ b/src/blocks/RelatedProducts/Component.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import React from 'react'
+
+interface Product {
+  slug: string
+  title: string
+}
+
+export const RelatedProducts: React.FC<{ products?: Product[] }> = ({ products = [] }) => {
+  if (!products.length) return null
+
+  return (
+    <section className="container mt-16">
+      <h2 className="text-2xl font-bold mb-6">Related products</h2>
+      <div className="grid gap-6 md:grid-cols-3">
+        {products.map((product) => (
+          <Link key={product.slug} href={`/p/${product.slug}`} className="block border rounded p-4">
+            {product.title}
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+

--- a/src/heros/ProductHero/index.tsx
+++ b/src/heros/ProductHero/index.tsx
@@ -1,18 +1,17 @@
-import { formatDateTime } from 'src/utilities/formatDateTime'
 import React from 'react'
 
-import type { Post } from '@/payload-types'
-
 import { Media } from '@/components/Media'
-import { formatAuthors } from '@/utilities/formatAuthors'
 
-export const PostHero: React.FC<{
-  post: Post
-}> = ({ post }) => {
-  const { categories, heroImage, populatedAuthors, publishedAt, title } = post
+interface Product {
+  title: string
+  categories?: { title?: string | null }[] | null
+  heroImage?: unknown
+}
 
-  const hasAuthors =
-    populatedAuthors && populatedAuthors.length > 0 && formatAuthors(populatedAuthors) !== ''
+export const ProductHero: React.FC<{
+  product: Product
+}> = ({ product }) => {
+  const { categories, heroImage, title } = product
 
   return (
     <div className="relative -mt-[10.4rem] flex items-end">
@@ -40,25 +39,6 @@ export const PostHero: React.FC<{
 
           <div className="">
             <h1 className="mb-6 text-3xl md:text-5xl lg:text-6xl">{title}</h1>
-          </div>
-
-          <div className="flex flex-col md:flex-row gap-4 md:gap-16">
-            {hasAuthors && (
-              <div className="flex flex-col gap-4">
-                <div className="flex flex-col gap-1">
-                  <p className="text-sm">Author</p>
-
-                  <p>{formatAuthors(populatedAuthors)}</p>
-                </div>
-              </div>
-            )}
-            {publishedAt && (
-              <div className="flex flex-col gap-1">
-                <p className="text-sm">Date Published</p>
-
-                <time dateTime={publishedAt}>{formatDateTime(publishedAt)}</time>
-              </div>
-            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add RelatedProducts block for product relationships
- swap PostHero for ProductHero without author/date
- update product page to use product components

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing secret key)*

------
https://chatgpt.com/codex/tasks/task_e_689f824fbd90832aa6329fc68191ab79