### PR TITLE
feat: update SEO plugin for products

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -11,17 +11,19 @@ import { FixedToolbarFeature, HeadingFeature, lexicalEditor } from '@payloadcms/
 import { searchFields } from '@/search/fieldOverrides'
 import { beforeSyncWithSearch } from '@/search/beforeSync'
 
-import { Page, Post } from '@/payload-types'
+import { Page, Product } from '@/payload-types'
 import { getServerSideURL } from '@/utilities/getURL'
 
-const generateTitle: GenerateTitle<Post | Page> = ({ doc }) => {
-  return doc?.title ? `${doc.title} | Payload Website Template` : 'Payload Website Template'
+const generateTitle: GenerateTitle<Product | Page> = ({ doc }) => {
+  return doc?.listingName
+    ? `${doc.listingName} | Payload Website Template`
+    : 'Payload Website Template'
 }
 
-const generateURL: GenerateURL<Post | Page> = ({ doc }) => {
+const generateURL: GenerateURL<Product | Page> = ({ doc }) => {
   const url = getServerSideURL()
 
-  return doc?.slug ? `${url}/${doc.slug}` : url
+  return doc?.slug ? `${url}/p/${doc.slug}` : url
 }
 
 export const plugins: Plugin[] = [


### PR DESCRIPTION
## Summary
- generate SEO titles from product listing names
- prefix product URLs with `/p/`
- replace Post references with Product

## Testing
- `pnpm lint`
- `pnpm test:int` *(fails: missing secret key)*
- `pnpm test:e2e` *(fails: --no-experimental-strip-types not allowed in NODE_OPTIONS)*

------
https://chatgpt.com/codex/tasks/task_e_689f8242d8b4832aaaa8f2eec2e06b84