### PR TITLE
Update pagination paths and product labels

### DIFF
--- a/src/components/PageRange/index.tsx
+++ b/src/components/PageRange/index.tsx
@@ -1,14 +1,18 @@
 import React from 'react'
 
 const defaultLabels = {
-  plural: 'Docs',
-  singular: 'Doc',
+  plural: 'Products',
+  singular: 'Product',
 }
 
 const defaultCollectionLabels = {
   posts: {
     plural: 'Posts',
     singular: 'Post',
+  },
+  products: {
+    plural: 'Products',
+    singular: 'Product',
   },
 }
 

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -34,7 +34,7 @@ export const Pagination: React.FC<{
             <PaginationPrevious
               disabled={!hasPrevPage}
               onClick={() => {
-                router.push(`/posts/page/${page - 1}`)
+                router.push(`/p/page/${page - 1}`)
               }}
             />
           </PaginationItem>
@@ -49,7 +49,7 @@ export const Pagination: React.FC<{
             <PaginationItem>
               <PaginationLink
                 onClick={() => {
-                  router.push(`/posts/page/${page - 1}`)
+                  router.push(`/p/page/${page - 1}`)
                 }}
               >
                 {page - 1}
@@ -61,7 +61,7 @@ export const Pagination: React.FC<{
             <PaginationLink
               isActive
               onClick={() => {
-                router.push(`/posts/page/${page}`)
+                router.push(`/p/page/${page}`)
               }}
             >
               {page}
@@ -72,7 +72,7 @@ export const Pagination: React.FC<{
             <PaginationItem>
               <PaginationLink
                 onClick={() => {
-                  router.push(`/posts/page/${page + 1}`)
+                  router.push(`/p/page/${page + 1}`)
                 }}
               >
                 {page + 1}
@@ -90,7 +90,7 @@ export const Pagination: React.FC<{
             <PaginationNext
               disabled={!hasNextPage}
               onClick={() => {
-                router.push(`/posts/page/${page + 1}`)
+                router.push(`/p/page/${page + 1}`)
               }}
             />
           </PaginationItem>


### PR DESCRIPTION
## Summary
- update pagination navigation to use `/p/page/`
- default PageRange labels use product terminology and include products collection

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing secret key)*

------
https://chatgpt.com/codex/tasks/task_e_689f824acb30832a81e6a249307947d8