### PR TITLE
refactor: centralize product type

### DIFF
--- a/src/app/(frontend)/p/[slug]/page.tsx
+++ b/src/app/(frontend)/p/[slug]/page.tsx
@@ -5,16 +5,7 @@ import { draftMode } from 'next/headers'
 import { getPayload } from 'payload'
 import configPromise from '@payload-config'
 import React, { cache } from 'react'
-
-// Types for product data returned from Payload
-interface Product {
-  slug: string
-  title: string
-  images?: { url: string; alt?: string }[]
-  shortDescription?: string
-  features?: { title: string; description: string }[]
-  tags?: string[]
-}
+import type { Product } from '@/types/product'
 
 type Args = {
   params: Promise<{ slug?: string }>

--- a/src/components/(marketing)/HomepageHero/index.tsx
+++ b/src/components/(marketing)/HomepageHero/index.tsx
@@ -3,15 +3,7 @@
 import { Media } from '@/components/Media'
 import { AnimatePresence, motion } from 'framer-motion'
 import React, { useEffect, useState } from 'react'
-
-type Product = {
-  slug?: string
-  title?: string
-  image?: any
-  meta?: {
-    image?: any
-  }
-}
+import type { Product } from '@/types/product'
 
 export const HomepageHero: React.FC<{ products: Product[] }> = ({ products }) => {
   const [index, setIndex] = useState(0)

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,0 +1,12 @@
+export interface Product {
+  slug: string
+  title: string
+  images?: { url: string; alt?: string }[]
+  shortDescription?: string
+  features?: { title: string; description: string }[]
+  tags?: string[]
+  categories?: { title?: string }[]
+  heroImage?: unknown
+  image?: unknown
+  meta?: { image?: unknown }
+}


### PR DESCRIPTION
## Summary
- introduce shared Product interface
- reuse Product type across page and homepage hero

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing secret key. A secret key is needed to secure Payload.)*

------
https://chatgpt.com/codex/tasks/task_e_689f8bb61ec4832a967636b11a2f3df2