### PR TITLE
Redirect /products/:slug to short path and document route

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ This template also pre-configured with the official [Payload Search Plugin](http
 
 If you are migrating an existing site or moving content to a new URL, you can use the `redirects` collection to create a proper redirect from old URLs to new ones. This will ensure that proper request status codes are returned to search engines and that your users are not left with a broken link. This template comes pre-configured with the official [Payload Redirects Plugin](https://payloadcms.com/docs/plugins/redirects) for complete redirect control from the admin panel. All redirects are fully integrated into the front-end website that comes with this template. See [Website](#website) for more details.
 
+### Built-in redirects
+
+- `/posts/:slug` → `/p/:slug`
+- `/products/:slug` → `/p/:slug`
+
 ## Jobs and Scheduled Publish
 
 We have configured [Scheduled Publish](https://payloadcms.com/docs/versions/drafts#scheduled-publish) which uses the [jobs queue](https://payloadcms.com/docs/jobs-queue/jobs) in order to publish or unpublish your content on a scheduled time. The tasks are run on a cron schedule and can also be run as a separate instance if needed.

--- a/redirects.js
+++ b/redirects.js
@@ -18,7 +18,13 @@ const redirects = async () => {
     permanent: true,
   }
 
-  const redirects = [internetExplorerRedirect, postsRedirect]
+  const productsRedirect = {
+    source: '/products/:slug',
+    destination: '/p/:slug',
+    permanent: true,
+  }
+
+  const redirects = [internetExplorerRedirect, postsRedirect, productsRedirect]
 
   return redirects
 }


### PR DESCRIPTION
## Summary
- redirect `/products/:slug` to short `/p/:slug` path
- document built-in redirects in README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Error: missing secret key. A secret key is needed to secure Payload)*

------
https://chatgpt.com/codex/tasks/task_e_689f91960ef8832abb932b7956126998