### PR TITLE
feat: cache payload client for API routes

### DIFF
--- a/src/app/(frontend)/(sitemaps)/p-sitemap.xml/route.ts
+++ b/src/app/(frontend)/(sitemaps)/p-sitemap.xml/route.ts
@@ -1,52 +1,51 @@
 import { getServerSideSitemap } from 'next-sitemap'
-import { getPayload } from 'payload'
-import config from '@payload-config'
 import { unstable_cache } from 'next/cache'
+import { getPayloadCached } from '@/utilities/getPayloadCached'
 
 const getProductsSitemap = unstable_cache(
-  async () => {
-    const payload = await getPayload({ config })
-    const SITE_URL =
-      process.env.NEXT_PUBLIC_SERVER_URL ||
-      process.env.VERCEL_PROJECT_PRODUCTION_URL ||
-      'https://example.com'
+    async () => {
+      const payload = await getPayloadCached()
+      const SITE_URL =
+        process.env.NEXT_PUBLIC_SERVER_URL ||
+        process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+        'https://example.com'
 
-    const results = await payload.find({
-      collection: 'products',
-      overrideAccess: false,
-      draft: false,
-      depth: 0,
-      limit: 1000,
-      pagination: false,
-      where: {
-        _status: {
-          equals: 'published',
+      const results = await payload.find({
+        collection: 'products',
+        overrideAccess: false,
+        draft: false,
+        depth: 0,
+        limit: 1000,
+        pagination: false,
+        where: {
+          _status: {
+            equals: 'published',
+          },
         },
-      },
-      select: {
-        slug: true,
-        updatedAt: true,
-      },
-    })
+        select: {
+          slug: true,
+          updatedAt: true,
+        },
+      })
 
-    const dateFallback = new Date().toISOString()
+      const dateFallback = new Date().toISOString()
 
-    const sitemap = results.docs
-      ? results.docs
-          .filter((product) => Boolean(product?.slug))
-          .map((product) => ({
-            loc: `${SITE_URL}/p/${product?.slug}`,
-            lastmod: product.updatedAt || dateFallback,
-          }))
-      : []
+      const sitemap = results.docs
+        ? results.docs
+            .filter((product) => Boolean(product?.slug))
+            .map((product) => ({
+              loc: `${SITE_URL}/p/${product?.slug}`,
+              lastmod: product.updatedAt || dateFallback,
+            }))
+        : []
 
-    return sitemap
-  },
-  ['p-sitemap'],
-  {
-    tags: ['p-sitemap'],
-  },
-)
+      return sitemap
+    },
+    ['p-sitemap'],
+    {
+      tags: ['p-sitemap'],
+    },
+  )
 
 export async function GET() {
   const sitemap = await getProductsSitemap()

--- a/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
+++ b/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
@@ -1,60 +1,59 @@
 import { getServerSideSitemap } from 'next-sitemap'
-import { getPayload } from 'payload'
-import config from '@payload-config'
 import { unstable_cache } from 'next/cache'
+import { getPayloadCached } from '@/utilities/getPayloadCached'
 
 const getPagesSitemap = unstable_cache(
-  async () => {
-    const payload = await getPayload({ config })
-    const SITE_URL =
-      process.env.NEXT_PUBLIC_SERVER_URL ||
-      process.env.VERCEL_PROJECT_PRODUCTION_URL ||
-      'https://example.com'
+    async () => {
+      const payload = await getPayloadCached()
+      const SITE_URL =
+        process.env.NEXT_PUBLIC_SERVER_URL ||
+        process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+        'https://example.com'
 
-    const results = await payload.find({
-      collection: 'pages',
-      overrideAccess: false,
-      draft: false,
-      depth: 0,
-      limit: 1000,
-      pagination: false,
-      where: {
-        _status: {
-          equals: 'published',
+      const results = await payload.find({
+        collection: 'pages',
+        overrideAccess: false,
+        draft: false,
+        depth: 0,
+        limit: 1000,
+        pagination: false,
+        where: {
+          _status: {
+            equals: 'published',
+          },
         },
-      },
-      select: {
-        slug: true,
-        updatedAt: true,
-      },
-    })
+        select: {
+          slug: true,
+          updatedAt: true,
+        },
+      })
 
-    const dateFallback = new Date().toISOString()
+      const dateFallback = new Date().toISOString()
 
-    const defaultSitemap = [
-      {
-        loc: `${SITE_URL}/search`,
-        lastmod: dateFallback,
-      },
-      {
-        loc: `${SITE_URL}/p`,
-        lastmod: dateFallback,
-      },
-    ]
+      const defaultSitemap = [
+        {
+          loc: `${SITE_URL}/search`,
+          lastmod: dateFallback,
+        },
+        {
+          loc: `${SITE_URL}/p`,
+          lastmod: dateFallback,
+        },
+      ]
 
-    const sitemap = results.docs
-      ? results.docs
-          .filter((page) => Boolean(page?.slug))
-          .map((page) => {
-            return {
-              loc: page?.slug === 'home' ? `${SITE_URL}/` : `${SITE_URL}/${page?.slug}`,
-              lastmod: page.updatedAt || dateFallback,
-            }
-          })
-      : []
+      const sitemap = results.docs
+        ? results.docs
+            .filter((page) => Boolean(page?.slug))
+            .map((page) => {
+              return {
+                loc: page?.slug === 'home' ? `${SITE_URL}/` : `${SITE_URL}/${page?.slug}`,
+                lastmod: page.updatedAt || dateFallback,
+              }
+            })
+        : []
 
-    return [...defaultSitemap, ...sitemap]
-  },
+      return [...defaultSitemap, ...sitemap]
+    },
   ['pages-sitemap'],
   {
     tags: ['pages-sitemap'],

--- a/src/app/(frontend)/(sitemaps)/products-sitemap.xml/route.ts
+++ b/src/app/(frontend)/(sitemaps)/products-sitemap.xml/route.ts
@@ -1,52 +1,51 @@
 import { getServerSideSitemap } from 'next-sitemap'
-import { getPayload } from 'payload'
-import config from '@payload-config'
 import { unstable_cache } from 'next/cache'
+import { getPayloadCached } from '@/utilities/getPayloadCached'
 
 const getProductsSitemap = unstable_cache(
-  async () => {
-    const payload = await getPayload({ config })
-    const SITE_URL =
-      process.env.NEXT_PUBLIC_SERVER_URL ||
-      process.env.VERCEL_PROJECT_PRODUCTION_URL ||
-      'https://example.com'
+    async () => {
+      const payload = await getPayloadCached()
+      const SITE_URL =
+        process.env.NEXT_PUBLIC_SERVER_URL ||
+        process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+        'https://example.com'
 
-    const results = await payload.find({
-      collection: 'products',
-      overrideAccess: false,
-      draft: false,
-      depth: 0,
-      limit: 1000,
-      pagination: false,
-      where: {
-        _status: {
-          equals: 'published',
+      const results = await payload.find({
+        collection: 'products',
+        overrideAccess: false,
+        draft: false,
+        depth: 0,
+        limit: 1000,
+        pagination: false,
+        where: {
+          _status: {
+            equals: 'published',
+          },
         },
-      },
-      select: {
-        slug: true,
-        updatedAt: true,
-      },
-    })
+        select: {
+          slug: true,
+          updatedAt: true,
+        },
+      })
 
-    const dateFallback = new Date().toISOString()
+      const dateFallback = new Date().toISOString()
 
-    const sitemap = results.docs
-      ? results.docs
-          .filter((product) => Boolean(product?.slug))
-          .map((product) => ({
-            loc: `${SITE_URL}/p/${product?.slug}`,
-            lastmod: product.updatedAt || dateFallback,
-          }))
-      : []
+      const sitemap = results.docs
+        ? results.docs
+            .filter((product) => Boolean(product?.slug))
+            .map((product) => ({
+              loc: `${SITE_URL}/p/${product?.slug}`,
+              lastmod: product.updatedAt || dateFallback,
+            }))
+        : []
 
-    return sitemap
-  },
-  ['products-sitemap'],
-  {
-    tags: ['products-sitemap'],
-  },
-)
+      return sitemap
+    },
+    ['products-sitemap'],
+    {
+      tags: ['products-sitemap'],
+    },
+  )
 
 export async function GET() {
   const sitemap = await getProductsSitemap()

--- a/src/app/(frontend)/next/preview/route.ts
+++ b/src/app/(frontend)/next/preview/route.ts
@@ -1,10 +1,7 @@
 import type { CollectionSlug, PayloadRequest } from 'payload'
-import { getPayload } from 'payload'
-
 import { draftMode } from 'next/headers'
 import { redirect } from 'next/navigation'
-
-import configPromise from '@payload-config'
+import { getPayloadCached } from '@/utilities/getPayloadCached'
 
 export async function GET(
   req: {
@@ -15,7 +12,7 @@ export async function GET(
     }
   } & Request,
 ): Promise<Response> {
-  const payload = await getPayload({ config: configPromise })
+  const payload = await getPayloadCached()
 
   const { searchParams } = new URL(req.url)
 

--- a/src/app/(frontend)/next/seed/route.ts
+++ b/src/app/(frontend)/next/seed/route.ts
@@ -1,12 +1,12 @@
-import { createLocalReq, getPayload } from 'payload'
+import { createLocalReq } from 'payload'
 import { seed } from '@/endpoints/seed'
-import config from '@payload-config'
 import { headers } from 'next/headers'
+import { getPayloadCached } from '@/utilities/getPayloadCached'
 
 export const maxDuration = 60 // This function can run for a maximum of 60 seconds
 
 export async function POST(): Promise<Response> {
-  const payload = await getPayload({ config })
+  const payload = await getPayloadCached()
   const requestHeaders = await headers()
 
   // Authenticate by passing request headers

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,6 +1,5 @@
 import type { NextRequest } from 'next/server'
-import { getPayload } from 'payload'
-import config from '@payload-config'
+import { getPayloadCached } from '@/utilities/getPayloadCached'
 
 export const runtime = 'nodejs'
 
@@ -12,7 +11,7 @@ const select = {
 }
 
 export async function GET(req: NextRequest): Promise<Response> {
-  const payload = await getPayload({ config })
+  const payload = await getPayloadCached()
   const { searchParams } = new URL(req.url)
 
   const limit = parseInt(searchParams.get('limit') ?? '50', 10)

--- a/src/app/api/random-product/route.ts
+++ b/src/app/api/random-product/route.ts
@@ -1,5 +1,4 @@
-import { getPayload } from 'payload'
-import config from '@payload-config'
+import { getPayloadCached } from '@/utilities/getPayloadCached'
 
 export const runtime = 'nodejs'
 
@@ -24,7 +23,7 @@ function pickWeightedDestination(destinations: any[]): any | undefined {
 }
 
 export async function GET(): Promise<Response> {
-  const payload = await getPayload({ config })
+  const payload = await getPayloadCached()
 
   const products = await payload.find({
     collection: 'products',

--- a/src/app/go/[slug]/route.ts
+++ b/src/app/go/[slug]/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server'
-import { getPayload } from 'payload'
-import configPromise from '@payload-config'
+import { getPayloadCached } from '@/utilities/getPayloadCached'
 
 import { getServerSideURL } from '@/utilities/getURL'
 
@@ -13,7 +12,7 @@ export async function GET(
   { params }: { params: { slug: string } },
 ): Promise<Response> {
   const { slug } = params
-  const payload = await getPayload({ config: configPromise })
+  const payload = await getPayloadCached()
 
   const { docs } = await payload.find<{ destinations?: any[] }>({
     collection: 'products',

--- a/src/utilities/getPayloadCached.ts
+++ b/src/utilities/getPayloadCached.ts
@@ -1,0 +1,5 @@
+import configPromise from '@payload-config'
+import { getPayload } from 'payload'
+import { cache } from 'react'
+
+export const getPayloadCached = cache(async () => getPayload({ config: configPromise }))


### PR DESCRIPTION
## Summary
- add shared `getPayloadCached` helper
- use cached payload client across API routes

## Testing
- `pnpm test:int` *(fails: missing secret key)*
- `pnpm test:e2e` *(fails: NODE_OPTIONS --no-experimental-strip-types not allowed)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689f919aeb50832aa475045198ead0d3