### PR TITLE
chore: remove unused custom scss

### DIFF
--- a/src/app/(payload)/layout.tsx
+++ b/src/app/(payload)/layout.tsx
@@ -7,7 +7,6 @@ import { handleServerFunctions, RootLayout } from '@payloadcms/next/layouts'
 import React from 'react'
 
 import { importMap } from './admin/importMap.js'
-import './custom.scss'
 
 type Args = {
   children: React.ReactNode


### PR DESCRIPTION
## Summary
- remove unused custom.scss file and import

## Testing
- `pnpm lint`
- `pnpm test:int` (fails: missing secret key)
- `pnpm test:e2e` (fails: --no-experimental-strip-types not allowed)


------
https://chatgpt.com/codex/tasks/task_e_689f91985c8c832aacceb95018aaca8f