### PR TITLE
refactor: centralize revalidation logic

### DIFF
--- a/src/Footer/hooks/revalidateFooter.ts
+++ b/src/Footer/hooks/revalidateFooter.ts
@@ -1,13 +1,14 @@
 import type { GlobalAfterChangeHook } from 'payload'
 
-import { revalidateTag } from 'next/cache'
+import { revalidate } from '@/hooks/revalidate'
 
 export const revalidateFooter: GlobalAfterChangeHook = ({ doc, req: { payload, context } }) => {
-  if (!context.disableRevalidate) {
-    payload.logger.info(`Revalidating footer`)
-
-    revalidateTag('global_footer')
-  }
+  revalidate({
+    context,
+    payload,
+    tag: 'global_footer',
+    logMessage: 'Revalidating footer',
+  })
 
   return doc
 }

--- a/src/Header/hooks/revalidateHeader.ts
+++ b/src/Header/hooks/revalidateHeader.ts
@@ -1,13 +1,14 @@
 import type { GlobalAfterChangeHook } from 'payload'
 
-import { revalidateTag } from 'next/cache'
+import { revalidate } from '@/hooks/revalidate'
 
 export const revalidateHeader: GlobalAfterChangeHook = ({ doc, req: { payload, context } }) => {
-  if (!context.disableRevalidate) {
-    payload.logger.info(`Revalidating header`)
-
-    revalidateTag('global_header')
-  }
+  revalidate({
+    context,
+    payload,
+    tag: 'global_header',
+    logMessage: 'Revalidating header',
+  })
 
   return doc
 }

--- a/src/collections/Pages/hooks/revalidatePage.ts
+++ b/src/collections/Pages/hooks/revalidatePage.ts
@@ -1,6 +1,6 @@
 import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
 
-import { revalidatePath, revalidateTag } from 'next/cache'
+import { revalidate } from '@/hooks/revalidate'
 
 import type { Page } from '../../../payload-types'
 
@@ -9,35 +9,38 @@ export const revalidatePage: CollectionAfterChangeHook<Page> = ({
   previousDoc,
   req: { payload, context },
 }) => {
-  if (!context.disableRevalidate) {
-    if (doc._status === 'published') {
-      const path = doc.slug === 'home' ? '/' : `/${doc.slug}`
-
-      payload.logger.info(`Revalidating page at path: ${path}`)
-
-      revalidatePath(path)
-      revalidateTag('pages-sitemap')
-    }
-
-    // If the page was previously published, we need to revalidate the old path
-    if (previousDoc?._status === 'published' && doc._status !== 'published') {
-      const oldPath = previousDoc.slug === 'home' ? '/' : `/${previousDoc.slug}`
-
-      payload.logger.info(`Revalidating old page at path: ${oldPath}`)
-
-      revalidatePath(oldPath)
-      revalidateTag('pages-sitemap')
-    }
+  if (doc._status === 'published') {
+    const path = doc.slug === 'home' ? '/' : `/${doc.slug}`
+    revalidate({
+      context,
+      payload,
+      path,
+      tag: 'pages-sitemap',
+      logMessage: `Revalidating page at path: ${path}`,
+    })
   }
+
+  // If the page was previously published, we need to revalidate the old path
+  if (previousDoc?._status === 'published' && doc._status !== 'published') {
+    const oldPath = previousDoc.slug === 'home' ? '/' : `/${previousDoc.slug}`
+    revalidate({
+      context,
+      payload,
+      path: oldPath,
+      tag: 'pages-sitemap',
+      logMessage: `Revalidating old page at path: ${oldPath}`,
+    })
+  }
+
   return doc
 }
 
-export const revalidateDelete: CollectionAfterDeleteHook<Page> = ({ doc, req: { context } }) => {
-  if (!context.disableRevalidate) {
-    const path = doc?.slug === 'home' ? '/' : `/${doc?.slug}`
-    revalidatePath(path)
-    revalidateTag('pages-sitemap')
-  }
+export const revalidateDelete: CollectionAfterDeleteHook<Page> = ({
+  doc,
+  req: { payload, context },
+}) => {
+  const path = doc?.slug === 'home' ? '/' : `/${doc?.slug}`
+  revalidate({ context, payload, path, tag: 'pages-sitemap' })
 
   return doc
 }

--- a/src/collections/Posts/hooks/revalidatePost.ts
+++ b/src/collections/Posts/hooks/revalidatePost.ts
@@ -1,6 +1,6 @@
 import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
 
-import { revalidatePath, revalidateTag } from 'next/cache'
+import { revalidate } from '@/hooks/revalidate'
 
 import type { Post } from '../../../payload-types'
 
@@ -9,36 +9,38 @@ export const revalidatePost: CollectionAfterChangeHook<Post> = ({
   previousDoc,
   req: { payload, context },
 }) => {
-  if (!context.disableRevalidate) {
-    if (doc._status === 'published') {
-      const path = `/p/${doc.slug}`
-
-      payload.logger.info(`Revalidating post at path: ${path}`)
-
-      revalidatePath(path)
-      revalidateTag('p-sitemap')
-    }
-
-    // If the post was previously published, we need to revalidate the old path
-    if (previousDoc._status === 'published' && doc._status !== 'published') {
-      const oldPath = `/p/${previousDoc.slug}`
-
-      payload.logger.info(`Revalidating old post at path: ${oldPath}`)
-
-      revalidatePath(oldPath)
-      revalidateTag('p-sitemap')
-    }
+  if (doc._status === 'published') {
+    const path = `/p/${doc.slug}`
+    revalidate({
+      context,
+      payload,
+      path,
+      tag: 'p-sitemap',
+      logMessage: `Revalidating post at path: ${path}`,
+    })
   }
+
+  // If the post was previously published, we need to revalidate the old path
+  if (previousDoc._status === 'published' && doc._status !== 'published') {
+    const oldPath = `/p/${previousDoc.slug}`
+    revalidate({
+      context,
+      payload,
+      path: oldPath,
+      tag: 'p-sitemap',
+      logMessage: `Revalidating old post at path: ${oldPath}`,
+    })
+  }
+
   return doc
 }
 
-export const revalidateDelete: CollectionAfterDeleteHook<Post> = ({ doc, req: { context } }) => {
-  if (!context.disableRevalidate) {
-    const path = `/p/${doc?.slug}`
-
-    revalidatePath(path)
-    revalidateTag('p-sitemap')
-  }
+export const revalidateDelete: CollectionAfterDeleteHook<Post> = ({
+  doc,
+  req: { payload, context },
+}) => {
+  const path = `/p/${doc?.slug}`
+  revalidate({ context, payload, path, tag: 'p-sitemap' })
 
   return doc
 }

--- a/src/hooks/revalidate.ts
+++ b/src/hooks/revalidate.ts
@@ -1,0 +1,40 @@
+import { revalidatePath, revalidateTag } from 'next/cache'
+import type { Payload } from 'payload'
+
+interface RevalidateOptions {
+  context?: {
+    disableRevalidate?: boolean
+  }
+  payload?: Payload
+  tag?: string | string[]
+  path?: string | string[]
+  logMessage?: string
+}
+
+export const revalidate = ({
+  context,
+  payload,
+  tag,
+  path,
+  logMessage,
+}: RevalidateOptions): void => {
+  if (context?.disableRevalidate) {
+    return
+  }
+
+  if (logMessage && payload) {
+    payload.logger.info(logMessage)
+  }
+
+  if (tag) {
+    const tags: string[] = Array.isArray(tag) ? tag : [tag]
+    tags.forEach((t) => revalidateTag(t))
+  }
+
+  if (path) {
+    const paths: string[] = Array.isArray(path) ? path : [path]
+    paths.forEach((p) => revalidatePath(p))
+  }
+}
+
+export default revalidate


### PR DESCRIPTION
## Summary
- add shared revalidate hook for tag and path invalidation
- refactor footer, header, page, and post hooks to use shared revalidate

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing secret key)*

------
https://chatgpt.com/codex/tasks/task_e_689f9198469c832a9feb975d5eec9691